### PR TITLE
Fixed broken project page

### DIFF
--- a/src/components/CrowdActionCard.tsx
+++ b/src/components/CrowdActionCard.tsx
@@ -36,13 +36,15 @@ export default function CrowdActionCard({ ...crowdAction }: CrowdAction) {
       className="bg-white rounded-xl overflow-hidden w-[300px] h-[492px] drop-shadow-lg relative"
       key={`${crowdAction.id} card`}
     >
-      <Image
-        src={`${staticUrl}${crowdAction.images.card}`}
-        alt={crowdAction.title}
-        width={300}
-        height={180}
-        className="max-w-[300px] max-h-[180px] h-[180px] w-[300px]"
-      />
+      {crowdAction?.images?.card && (
+        <Image
+          src={`${staticUrl}${crowdAction.images.card}`}
+          alt={crowdAction.title}
+          width={300}
+          height={180}
+          className="max-w-[300px] max-h-[180px] h-[180px] w-[300px]"
+        />
+      )}
       <CrowdActionChipList
         status={crowdAction.status}
         joinStatus={crowdAction.joinStatus}
@@ -53,11 +55,13 @@ export default function CrowdActionCard({ ...crowdAction }: CrowdAction) {
         <p className="font-bold text-xl text-primary-400">
           {crowdAction.title}
         </p>
-        <p className="mt-4 text-primary-300 text-sm leading-6">
-          {crowdAction.description.length > 175
-            ? `${crowdAction.description.substring(0, 175)}...`
-            : crowdAction.description}
-        </p>
+        {crowdAction?.description && (
+          <p className="mt-4 text-primary-300 text-sm leading-6">
+            {crowdAction.description.length > 175
+              ? `${crowdAction.description.substring(0, 175)}...`
+              : crowdAction.description}
+          </p>
+        )}
       </div>
       <div className="py-5 px-5 flex justify-center absolute bottom-0 left-0 right-0">
         <Link

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -170,7 +170,7 @@ export default function NavBar() {
                 {t('app:navbar.team')}
               </Link>
               <Link
-                href="/projects"
+                href="/projects?page=1"
                 onClick={() => {
                   setNavbar(false);
                 }}

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -557,7 +557,7 @@ export default function ProjectListPage({ projects, pagination }: any) {
 }
 
 export async function getServerSideProps({ query, locale }: any) {
-  const page: string = query.page;
+  const page: string = query?.page || 1;
 
   const { items, pageInfo } = await fetch(
     `https://api.collaction.org/v1/crowdactions?page=${page}&pageSize=3`


### PR DESCRIPTION
This PR closes #104 

The server request must include the query parameter `page` for the **/projects** page. The server request is currently being passed with `page` value as `undefined` which is why it produces an error. In this PR, the problem was fixed by adding the default value of a `page` if it is `undefined`.

Moreover, a safety check for `images` and `description` was added to the `src\components\CrowdActionCard.tsx` component because the page would crash without those values.

![image](https://user-images.githubusercontent.com/44311424/232125358-8acb2d14-cbf6-4389-8bff-7a3ff6979b25.png)
